### PR TITLE
modifying yield_csv function to return as it is response from rest call

### DIFF
--- a/pyairpal/__init__.py
+++ b/pyairpal/__init__.py
@@ -184,7 +184,7 @@ class Airpal(object):
         # loop finished, return current job info.
         return job
 
-    def yield_csv(self, location):
+    def yield_csv(self, location, raw_response=False):
         """
         Function to yield a .csv file from a location string (PATH of URL)
         :param location: String to PATH of CSV object on AirPal
@@ -197,7 +197,12 @@ class Airpal(object):
                                                                     location),
                                           "get",
                                           extraheaders={'Accept': "*/*"})
-        return response
+	if raw_response:
+            return response
+        elif fd:
+            return io.StringIO(response.content.decode('utf8'))
+        else:
+            return response.content
 
     def execute(self, query):
         """

--- a/pyairpal/__init__.py
+++ b/pyairpal/__init__.py
@@ -184,12 +184,11 @@ class Airpal(object):
         # loop finished, return current job info.
         return job
 
-    def yield_csv(self, location, fd=False):
+    def yield_csv(self, location):
         """
         Function to yield a .csv file from a location string (PATH of URL)
         :param location: String to PATH of CSV object on AirPal
-        :param fd: Boolean, if True, return a File Descriptor-like object instead of content.
-        :return: String or FD-like object if fd=True
+        :return: direct response from get rest call
         """
         logger.debug('yield_csv:')
         status, response = self.rest_call("{0}://{1}:{2}{3}".format(self.__ap_scheme,
@@ -198,10 +197,7 @@ class Airpal(object):
                                                                     location),
                                           "get",
                                           extraheaders={'Accept': "*/*"})
-        if fd:
-            return io.StringIO(response.content.decode('utf8'))
-        else:
-            return response.content
+        return response
 
     def execute(self, query):
         """

--- a/pyairpal/__init__.py
+++ b/pyairpal/__init__.py
@@ -188,7 +188,9 @@ class Airpal(object):
         """
         Function to yield a .csv file from a location string (PATH of URL)
         :param location: String to PATH of CSV object on AirPal
-        :return: direct response from get rest call
+	:param fd: Boolean, if True, return a File Descriptor-like object instead of content.
+	:param raw_response: Boolean, if True, return raw response instead of content.
+        :return: String or raw response if raw_response=True or FD-like object if fd=True
         """
         logger.debug('yield_csv:')
         status, response = self.rest_call("{0}://{1}:{2}{3}".format(self.__ap_scheme,

--- a/pyairpal/__init__.py
+++ b/pyairpal/__init__.py
@@ -184,7 +184,7 @@ class Airpal(object):
         # loop finished, return current job info.
         return job
 
-    def yield_csv(self, location, raw_response=False):
+    def yield_csv(self, location, fd=False, raw_response=False):
         """
         Function to yield a .csv file from a location string (PATH of URL)
         :param location: String to PATH of CSV object on AirPal


### PR DESCRIPTION
If file is too large (say more than 6GB) it can not be load into RAM in one call. Clients needs to get file into the chunks. For chunking purpose 'yield_csv' function should return response as it is from the rest call.

Here is the example code snippet:

import pyairpal
def download_file(location):
    response = AirpalConnection.yield_csv(location)
    with open(output_file, "w") as output_fd:
        for chunk in response.iter_content(chunk_size=1000000000):
                if chunk:
                    output_fd.write(chunk)
                    output_fd.flush()
        response.close()

      